### PR TITLE
Make WebDirection mandatory in Inclinateion #196

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 * [Add strict formatting of GUID #199](https://github.com/OCXStandard/OCX_Schema/issues/199)
 * [Material grade aligned with IACS Unified Requirements S6 “Use of Steel Grades for Various Hull Members – Ships of 90m in Length and Above – Rev.9 Corr.2 Nov 2021” Table 7 #182](https://github.com/OCXStandard/OCX_Schema/issues/182)
 * [Change LBarOF local properties to reference global properties #189](https://github.com/OCXStandard/OCX_Schema/issues/189)
+* [Make FlangeDirection mandatory for Inclination #196](https://github.com/OCXStandard/OCX_Schema/issues/196)
 
 ### Removed
 * [PhysicalProperties has been replaced by MassProperties #180](https://github.com/OCXStandard/OCX_Schema/issues/180)


### PR DESCRIPTION
WebDirection is mandatory:

<img width="391" height="307" alt="image" src="https://github.com/user-attachments/assets/4c082a64-0a94-4a5d-b35c-6da343a47fb9" />

## Summary by Sourcery

Documentation:
- Add a changelog entry for making FlangeDirection mandatory for Inclination (issue #196).