### PR TITLE
Fixed substitution group for RectangularMickeyMouseEars #174#179

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 * [Material grade aligned with IACS Unified Requirements S6 “Use of Steel Grades for Various Hull Members – Ships of 90m in Length and Above – Rev.9 Corr.2 Nov 2021” Table 7 #182](https://github.com/OCXStandard/OCX_Schema/issues/182)
 * [Change LBarOF local properties to reference global properties #189](https://github.com/OCXStandard/OCX_Schema/issues/189)
 * [Make FlangeDirection mandatory for Inclination #196](https://github.com/OCXStandard/OCX_Schema/issues/196)
+* [Make RectangularMickeyMouseEars  part of the ParametricHole2D substitution group #174](https://github.com/OCXStandard/OCX_Schema/issues/174)
 
 ### Removed
 * [PhysicalProperties has been replaced by MassProperties #180](https://github.com/OCXStandard/OCX_Schema/issues/180)

--- a/ocx/OCX_Schema.xsd
+++ b/ocx/OCX_Schema.xsd
@@ -1168,7 +1168,11 @@
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element ref="ocx:WebDirection"/>
-			<xs:element ref="ocx:FlangeDirection" minOccurs="0"/>
+			<xs:element ref="ocx:FlangeDirection">
+				<xs:annotation>
+					<xs:documentation>Direction of the stiffener flange. allways required to determine the material side of symmetric profiles.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element ref="ocx:Position"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -4853,7 +4857,7 @@ either a sweep direction and length or a sweep curve.</xs:documentation>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
-	<xs:element name="RectangularMickeyMouseEars" type="ocx:RectangularMickeyMouseEars_T">
+	<xs:element name="RectangularMickeyMouseEars" type="ocx:RectangularMickeyMouseEars_T" substitutionGroup="ocx:ParametricHole2D">
 		<xs:annotation>
 			<xs:documentation>A rectangular hole with corner radii in the form of Mickey Mouse ears.</xs:documentation>
 		</xs:annotation>


### PR DESCRIPTION
## Summary by Sourcery

Align RectangularMickeyMouseEars with the ParametricHole2D substitution group and document the change.

Bug Fixes:
- Correct RectangularMickeyMouseEars schema membership so it participates in the ParametricHole2D substitution group as intended.

Documentation:
- Add a changelog entry describing the RectangularMickeyMouseEars ParametricHole2D substitution group fix.