### PR TITLE
Change RectangularTube properties #195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 * [Change LBarOF local properties to reference global properties #189](https://github.com/OCXStandard/OCX_Schema/issues/189)
 * [Make FlangeDirection mandatory for Inclination #196](https://github.com/OCXStandard/OCX_Schema/issues/196)
 * [Make RectangularMickeyMouseEars  part of the ParametricHole2D substitution group #174](https://github.com/OCXStandard/OCX_Schema/issues/174)
+* [Change RectangularTube local properties to reference global properties #195](https://github.com/OCXStandard/OCX_Schema/issues/195)
 
 ### Removed
 * [PhysicalProperties has been replaced by MassProperties #180](https://github.com/OCXStandard/OCX_Schema/issues/180)

--- a/ocx/OCX_Schema.xsd
+++ b/ocx/OCX_Schema.xsd
@@ -5295,21 +5295,9 @@ either a sweep direction and length or a sweep curve.</xs:documentation>
 	</xs:element>
 	<xs:complexType name="RectangularTube_T">
 		<xs:sequence>
-			<xs:element name="Height" type="ocx:Quantity_T">
-				<xs:annotation>
-					<xs:documentation>Profile outer diameter.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="Width" type="ocx:Quantity_T">
-				<xs:annotation>
-					<xs:documentation>Profile width.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="Thickness" type="ocx:Quantity_T">
-				<xs:annotation>
-					<xs:documentation>Wall thickness.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
+			<xs:element ref="ocx:Height"/>
+			<xs:element ref="ocx:Width"/>
+			<xs:element ref="ocx:Thickness"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:element name="UserDefinedBarSection" type="ocx:UserDefinedBarSection_T">


### PR DESCRIPTION
## Summary by Sourcery

Align RectangularTube element property definitions with global property references in the OCX schema.

Enhancements:
- Update RectangularTube local properties to reference shared global property definitions for consistency across the schema.

Documentation:
- Document the RectangularTube property change in the changelog as a linked issue entry.