### PR TITLE
Fix documentation of SuperElliptical #175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 * [Add Density to BulkCargo #185](https://github.com/OCXStandard/OCX_Schema/issues/185)
 * [Add MinimumBallastDraught to PrincipalParticulars #184](https://github.com/OCXStandard/OCX_Schema/issues/184)
 * [Add optional volume properties for to MassProperties #180](https://github.com/OCXStandard/OCX_Schema/issues/180)
+* [Add normal Ellipse to Hole2D catalogue and fix SuperElliptical #175](https://github.com/OCXStandard/OCX_Schema/issues/175)
 
 ### Changed
 * [Add strict formatting of GUID #199](https://github.com/OCXStandard/OCX_Schema/issues/199)
@@ -28,12 +29,15 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 * [Change LBarOF local properties to reference global properties #189](https://github.com/OCXStandard/OCX_Schema/issues/189)
 * [Make FlangeDirection mandatory for Inclination #196](https://github.com/OCXStandard/OCX_Schema/issues/196)
 * [Make RectangularMickeyMouseEars  part of the ParametricHole2D substitution group #174](https://github.com/OCXStandard/OCX_Schema/issues/174)
-* [Change RoundBar Heght with Diameter #177](https://github.com/OCXStandard/OCX_Schema/issues/177)
+* [Change RoundBar Height with Diameter #177](https://github.com/OCXStandard/OCX_Schema/issues/177)
 
 ### Removed
 * [PhysicalProperties has been replaced by MassProperties #180](https://github.com/OCXStandard/OCX_Schema/issues/180)
 * [DryWeight has been replaced with MouldedDryWeight #180](https://github.com/OCXStandard/OCX_Schema/issues/180)
 * [CenterOfGravity has been replaced with MouldedCenterOfGravity #180](https://github.com/OCXStandard/OCX_Schema/issues/180)
+
+### Deprecated
+* [SuperElliptical will be removed from the schema in a future release and is replaced by Ellipse #175](https://github.com/OCXStandard/OCX_Schema/issues/175)
 
 ## [3.1.0] - 2025.05.15
 

--- a/ocx/OCX_Schema.xsd
+++ b/ocx/OCX_Schema.xsd
@@ -4815,12 +4815,20 @@ either a sweep direction and length or a sweep curve.</xs:documentation>
 		<xs:complexContent>
 			<xs:extension base="ocx:ParametricHole2D_T">
 				<xs:sequence>
-					<xs:element ref="ocx:Height"/>
-					<xs:element ref="ocx:Width"/>
+					<xs:element ref="ocx:MajorDiameter">
+						<xs:annotation>
+							<xs:documentation>The ellipse major diameter. == 2a.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element ref="ocx:MinorDiameter">
+						<xs:annotation>
+							<xs:documentation>The ellipse minor diameter  ==2b.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 				</xs:sequence>
-				<xs:attribute name="exponent" type="xs:double" use="required">
+				<xs:attribute name="exponent" type="xs:double" use="optional" default="2.0">
 					<xs:annotation>
-						<xs:documentation>The exponent of the super ellipse equation (x/Height)**e + (y/Width)**e = 1. If e=2.5 the result is a super ellipse while e=2.0 results in a normal ellipse.</xs:documentation>
+						<xs:documentation>The exponent of the super ellipse equation. If e=2.5 the result is a super ellipse while e=2.0 results in a normal ellipse.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 			</xs:extension>
@@ -6342,4 +6350,22 @@ and represents the full load condition. The scantling draught is to be not less 
 			<xs:documentation>The physical or mass dry weight of the structure part.</xs:documentation>
 		</xs:annotation>
 	</xs:element>
+	<xs:element name="Ellipse" type="ocx:Ellipse_T" substitutionGroup="ocx:ParametricHole2D">
+		<xs:annotation>
+			<xs:documentation>A super-elliptical hole. It can also describe a true ellipse.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="Ellipse_T" abstract="true">
+		<xs:annotation>
+			<xs:documentation>Type definition of a parametric Ellipse</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="ocx:ParametricHole2D_T">
+				<xs:sequence>
+					<xs:element ref="ocx:MajorDiameter"/>
+					<xs:element ref="ocx:MinorDiameter"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
## Summary by Sourcery

Deprecate the SuperElliptical hole definition in favor of a standard Ellipse and update references accordingly.

Enhancements:
- Correct the RoundBar change log entry text from using a misspelled height term to diameter.

Documentation:
- Document addition of Ellipse to the Hole2D catalogue and deprecation of SuperElliptical in the changelog, including the new Deprecated section and related issue reference.