### PR TITLE
Deleted WebStiffenerRef_T #170

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 * [PhysicalProperties has been replaced by MassProperties #180](https://github.com/OCXStandard/OCX_Schema/issues/180)
 * [DryWeight has been replaced with MouldedDryWeight #180](https://github.com/OCXStandard/OCX_Schema/issues/180)
 * [CenterOfGravity has been replaced with MouldedCenterOfGravity #180](https://github.com/OCXStandard/OCX_Schema/issues/180)
+* [Delete WebStiffenerRef_T as it is not used #170](https://github.com/OCXStandard/OCX_Schema/issues/170)
 
 ### Deprecated
 * [SuperElliptical will be removed from the schema in a future release and is replaced by Ellipse #175](https://github.com/OCXStandard/OCX_Schema/issues/175)

--- a/ocx/OCX_Schema.xsd
+++ b/ocx/OCX_Schema.xsd
@@ -1749,20 +1749,6 @@
 			</xs:complexContent>
 		</xs:complexType>
 	</xs:element>
-	<xs:complexType name="WebStiffenerRef_T">
-		<xs:annotation>
-			<xs:documentation>Type definition of WebStiffener connection.</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="ocx:ReferenceBase_T">
-				<xs:attribute ref="ocx:position">
-					<xs:annotation>
-						<xs:documentation>The position of the web stiffener relative to the penetrating stiffener end.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
 	<xs:element name="WebStiffener" type="ocx:WebStiffener_T">
 		<xs:annotation>
 			<xs:documentation>Connection configuration with one web stiffener with a single bracket connection.</xs:documentation>


### PR DESCRIPTION
The type is not used. Change has no impact.

## Summary by Sourcery

Documentation:
- Add a changelog entry describing the removal of the unused WebStiffenerRef_T type.