### PR TITLE
Add OTHER to newBuildingSocietyName #166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 * ``Security`` in case of vulnerabilities.
 
 
-## [3.2.rc1] - 2025.11.30
+## [3.2.rc1] - 2025.12.03
 
 ### Added
 * [Add Support renewal thickness #9](https://github.com/OCXStandard/OCX_Schema/issues/9)
@@ -22,6 +22,7 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 * [Add MinimumBallastDraught to PrincipalParticulars #184](https://github.com/OCXStandard/OCX_Schema/issues/184)
 * [Add optional volume properties for to MassProperties #180](https://github.com/OCXStandard/OCX_Schema/issues/180)
 * [Add normal Ellipse to Hole2D catalogue and fix SuperElliptical #175](https://github.com/OCXStandard/OCX_Schema/issues/175)
+* [Add OTHER to newbuildingSocietyName #166](https://github.com/OCXStandard/OCX_Schema/issues/166)
 
 ### Changed
 * [Add strict formatting of GUID #199](https://github.com/OCXStandard/OCX_Schema/issues/199)

--- a/ocx/OCX_Schema.xsd
+++ b/ocx/OCX_Schema.xsd
@@ -5542,7 +5542,7 @@ either a sweep direction and length or a sweep curve.</xs:documentation>
 			</xs:enumeration>
 			<xs:enumeration value="IRS">
 				<xs:annotation>
-					<xs:documentation>	Indian Register of Shipping.</xs:documentation>
+					<xs:documentation>Indian Register of Shipping.</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="KR">
@@ -5623,6 +5623,11 @@ either a sweep direction and length or a sweep curve.</xs:documentation>
 			<xs:enumeration value="VR">
 				<xs:annotation>
 					<xs:documentation>Vietnam Register of Shipping.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OTHER">
+				<xs:annotation>
+					<xs:documentation>Any other society not in the list.</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>


### PR DESCRIPTION
## Summary by Sourcery

Add a new OTHER option to the newbuildingSocietyName schema field and document the change in the release changelog.

Enhancements:
- Extend the schema for newbuildingSocietyName to support an OTHER value.

Documentation:
- Update the 3.2.rc1 changelog entry date and list the new OTHER option for newbuildingSocietyName.