### PR TITLE
Surface AND SurfaceCollection #201

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
     **Impact:** Translator change (new enumerator field)
 
 ### Changed
+* [Extend ReferenceSurfaces to allow for a combination of Surface and SurfaceColecction #201](https://github.com/OCXStandard/OCX_Schema/issues/201)
+
+    **Impact:** None (only impact validation)
+
 * [Add strict formatting of GUID #199](https://github.com/OCXStandard/OCX_Schema/issues/199)
 
     **Impact:** None (GUID format validation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
     **Impact:** Translator change (new enumerator field)
 
 ### Changed
-* [Extend ReferenceSurfaces to allow for a combination of Surface and SurfaceColecction #201](https://github.com/OCXStandard/OCX_Schema/issues/201)
+* [Extend ReferenceSurfaces to allow for a combination of Surface and SurfaceCollection #201](https://github.com/OCXStandard/OCX_Schema/issues/201)
 
     **Impact:** None (only impact validation)
 

--- a/ocx/OCX_Schema.xsd
+++ b/ocx/OCX_Schema.xsd
@@ -3014,8 +3014,8 @@
 		<xs:annotation>
 			<xs:documentation>Type definition of a collection of surfaces.</xs:documentation>
 		</xs:annotation>
-		<xs:choice>
-			<xs:element ref="ocx:Surface" minOccurs="0" maxOccurs="unbounded"/>
+		<xs:choice maxOccurs="unbounded">
+			<xs:element ref="ocx:Surface" maxOccurs="unbounded"/>
 			<xs:element ref="ocx:SurfaceCollection" maxOccurs="unbounded"/>
 		</xs:choice>
 	</xs:complexType>


### PR DESCRIPTION
## Summary by Sourcery

Extend ReferenceSurfaces to support both Surface and SurfaceCollection references and document the change in the changelog as a validation-only impact.

Enhancements:
- Allow ReferenceSurfaces to reference a combination of Surface and SurfaceCollection entities.
- Document the ReferenceSurfaces extension in the changelog with a note about its validation-only impact.