### PR TITLE
Add Aluminium material #181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 ## [3.2.0rc1] - 2025.12.03
 
 ### Added
+* [Add support for Aluminium material #181](https://github.com/OCXStandard/OCX_Schema/issues/181)
+
+    **Impact:** None, optional entity
+
 * [Add Support renewal thickness #9](https://github.com/OCXStandard/OCX_Schema/issues/9)
     
     **Impact:** None (optional fields)

--- a/ocx/OCX_Schema.xsd
+++ b/ocx/OCX_Schema.xsd
@@ -4574,6 +4574,7 @@ either a sweep direction and length or a sweep curve.</xs:documentation>
 			<xs:extension base="ocx:DescriptionBase_T">
 				<xs:sequence>
 					<xs:element ref="ocx:Material" maxOccurs="unbounded"/>
+					<xs:element ref="ocx:Aluminium" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
@@ -6370,6 +6371,56 @@ and represents the full load condition. The scantling draught is to be not less 
 	<xs:element name="WebRenewalThickness" type="ocx:Quantity_T">
 		<xs:annotation>
 			<xs:documentation>The web renewal thickness of the profile. Renewal thickness refers to the minimum allowable web thickness, below which steel renewal must be carried out.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="Aluminium" type="ocx:Aluminium_T">
+		<xs:annotation>
+			<xs:documentation>High-strength, corrosion-resistant alloy commonly used in marine, aerospace, and structural applications</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="Aluminium_T">
+		<xs:complexContent>
+			<xs:extension base="ocx:DescriptionBase_T">
+				<xs:sequence>
+					<xs:element ref="ocx:Density"/>
+					<xs:element ref="ocx:YoungsModulus"/>
+					<xs:element ref="ocx:PoissonRatio"/>
+					<xs:element ref="ocx:UnWeldedYieldStrength"/>
+					<xs:element ref="ocx:WeldedYieldStrength"/>
+					<xs:element ref="ocx:UnWeldedTensileStrength"/>
+					<xs:element ref="ocx:WeldedTensileStrength"/>
+				</xs:sequence>
+				<xs:attribute name="standardReference">
+					<xs:annotation>
+						<xs:documentation>A reference to the associated alloy standard.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="alloyDesignation" type="xs:string" use="required">
+					<xs:annotation>
+						<xs:documentation>The alloy according to e.g. the International Alloy Designation System (AA)</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="UnWeldedYieldStrength" type="ocx:Quantity_T">
+		<xs:annotation>
+			<xs:documentation>Yield strength of the base material before welding.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="WeldedYieldStrength" type="ocx:Quantity_T">
+		<xs:annotation>
+			<xs:documentation>Yield strength. Properties after welding, where strength typically decreases due to thermal effects.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="UnWeldedTensileStrength" type="ocx:Quantity_T">
+		<xs:annotation>
+			<xs:documentation> The maximum stress the material can withstand before breaking. Properties of the base material before welding.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:element name="WeldedTensileStrength" type="ocx:Quantity_T">
+		<xs:annotation>
+			<xs:documentation>The maximum stress the material can withstand before breaking. Properties after welding, where strength typically decreases due to thermal effects.</xs:documentation>
 		</xs:annotation>
 	</xs:element>
 </xs:schema>


### PR DESCRIPTION
## Summary by Sourcery

Add support for an optional Aluminium material entity to the schema.

New Features:
- Introduce an optional Aluminium material entity to the OCX schema.

Documentation:
- Document the new Aluminium material support and its impact in the changelog.