### PR TITLE
Surface and Panel must support multiple outer contours/face boundary …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 * ``Security`` in case of vulnerabilities.
 
 
+## [3.2.0rc3] - 2026.01.08
+
+
+### Changed
+* [Surface and Panel must support multiple outer contours/face boundary curves #233](https://github.com/OCXStandard/OCX_Schema/issues/233)
+
+    **Impact:** Translator change (Cardinality change)
+
+* [StiffenedBy need to support a combination of Stiffener and EdgeReinforcement #200](https://github.com/OCXStandard/OCX_Schema/issues/200)
+
+  **Impact:** Translator change (Cardinality change)
+
 ## [3.2.0rc2] - 2026.01.07
 Bump to 3.2.0rc2 and publish release candidate
 

--- a/ocx/OCX_Schema.xsd
+++ b/ocx/OCX_Schema.xsd
@@ -1283,7 +1283,7 @@
 						</xs:annotation>
 					</xs:element>
 					<xs:element ref="ocx:MassProperties" minOccurs="0"/>
-					<xs:element ref="ocx:OuterContour" minOccurs="0"/>
+					<xs:element ref="ocx:OuterContour" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element ref="ocx:StiffenedBy" minOccurs="0"/>
 					<xs:element ref="ocx:SplitBy" minOccurs="0"/>
 					<xs:element ref="ocx:CutBy" minOccurs="0">
@@ -3040,7 +3040,7 @@
 		<xs:complexContent>
 			<xs:extension base="ocx:GeometryRepresentation_T">
 				<xs:sequence>
-					<xs:element ref="ocx:FaceBoundaryCurve" minOccurs="0">
+					<xs:element ref="ocx:FaceBoundaryCurve" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation> A collection of 3D curves making up a closed boundary. To be used whenever the surface need to be bounded.</xs:documentation>
 						</xs:annotation>


### PR DESCRIPTION
…curves #233

## Summary by Sourcery

Update OCX schema and release notes to reflect cardinality changes for surface/panel contours and stiffening relationships.

Enhancements:
- Adjust schema cardinality to support multiple outer contours/face boundary curves for surfaces and panels.
- Allow StiffenedBy relationships to reference combinations of Stiffener and EdgeReinforcement elements.

Documentation:
- Add 3.2.0rc3 changelog entry documenting schema cardinality changes impacting translators.