### PR TITLE
Wrong naming of MassProperty element #243

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to the Python [PEP 440 versioning recommendations](http
 * ``Fixed`` for any bug fixes.
 * ``Security`` in case of vulnerabilities.
 
+## [3.2.0rc6] - 2026.02.08
+
+Bump to 3.2.0rc6 and publish release candidate
+
+
+## [3.2.0rc6] - 2026.02.08
+### Changed
+* [Wrong naming of MassProperty element #243](https://github.com/OCXStandard/OCX_Schema/issues/243)
+
+    **Impact:** Translator change (Renaming entity from PhysicalMouldedCenterOfGravity to PhysicalCenterOfGravity)
 
 
 ## [3.2.0rc5] - 2026.02.02

--- a/ocx/OCX_Schema.xsd
+++ b/ocx/OCX_Schema.xsd
@@ -1883,18 +1883,18 @@
 			<xs:documentation>Type definition of mass properties of structure objects (weight and centre of gravity).</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element ref="ocx:MouldedDryWeight">
-				<xs:annotation>
-					<xs:documentation>The idealised moulded weight of the structure part.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
+			<xs:element ref="ocx:MouldedDryWeight"/>
 			<xs:element ref="ocx:MouldedCenterOfGravity">
 				<xs:annotation>
 					<xs:documentation>The idealised moulded centre of gravity of the structure part.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element ref="ocx:PhysicalDryWeight" minOccurs="0"/>
-			<xs:element ref="ocx:PhysicalMouldedCenterOfGravity" minOccurs="0"/>
+			<xs:element ref="ocx:PhysicalDryWeight" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation> The physical volumetric dry weight  of the structure part</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element ref="ocx:PhysicalCenterOfGravity" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:element name="CutBy" type="ocx:CutBy_T">
@@ -6407,12 +6407,12 @@ and represents the full load condition. The scantling draught is to be not less 
 	</xs:element>
 	<xs:element name="PhysicalDryWeight" type="ocx:Quantity_T">
 		<xs:annotation>
-			<xs:documentation> The physical or mass centre of gravity of the structure part</xs:documentation>
+			<xs:documentation> The physical volumetric dry weght  of the structure part</xs:documentation>
 		</xs:annotation>
 	</xs:element>
-	<xs:element name="PhysicalMouldedCenterOfGravity" type="ocx:Point3D_T">
+	<xs:element name="PhysicalCenterOfGravity" type="ocx:Point3D_T">
 		<xs:annotation>
-			<xs:documentation>The physical or mass dry weight of the structure part.</xs:documentation>
+			<xs:documentation>The physical volumetric mass center of gravity of the structure part.</xs:documentation>
 		</xs:annotation>
 	</xs:element>
 	<xs:element name="Ellipse" type="ocx:Ellipse_T" substitutionGroup="ocx:ParametricHole2D">


### PR DESCRIPTION
The MassProperty the physical center of gravity has been wronly named PhysicalMouldedCenterOfGravity. Change to PhysicalCenterOfGravity

## Summary by Sourcery

Rename the MassProperty element for physical center of gravity and bump the schema version for a new release candidate.

Enhancements:
- Rename the MassProperty entity from PhysicalMouldedCenterOfGravity to PhysicalCenterOfGravity to correct its naming.

Build:
- Bump project version to 3.2.0rc6 as a new release candidate.

Documentation:
- Update the changelog with the 3.2.0rc6 release notes describing the MassProperty rename.